### PR TITLE
Removes `node_type` from `UiNodeInputAttributes`

### DIFF
--- a/src/models/ui_node_input_attributes.rs
+++ b/src/models/ui_node_input_attributes.rs
@@ -28,9 +28,6 @@ pub struct UiNodeInputAttributes {
     /// The input's element name.
     #[serde(rename = "name")]
     pub name: String,
-    /// NodeType represents this node's types. It is a mirror of `node.type` and is primarily used to allow compatibility with OpenAPI 3.0.  In this struct it technically always is \"input\". text Text input Input img Image a Anchor script Script div Division
-    #[serde(rename = "node_type")]
-    pub node_type: NodeTypeEnum,
     /// OnClick may contain javascript which should be executed on click. This is primarily used for WebAuthn.  Deprecated: Using OnClick requires the use of eval() which is a security risk. Use OnClickTrigger instead.
     #[serde(rename = "onclick", skip_serializing_if = "Option::is_none")]
     pub onclick: Option<String>,
@@ -59,14 +56,13 @@ pub struct UiNodeInputAttributes {
 
 impl UiNodeInputAttributes {
     /// InputAttributes represents the attributes of an input node
-    pub fn new(disabled: bool, name: String, node_type: NodeTypeEnum, r#type: TypeEnum) -> UiNodeInputAttributes {
+    pub fn new(disabled: bool, name: String, r#type: TypeEnum) -> UiNodeInputAttributes {
         UiNodeInputAttributes {
             autocomplete: None,
             disabled,
             label: None,
             maxlength: None,
             name,
-            node_type,
             onclick: None,
             onclick_trigger: None,
             onload: None,


### PR DESCRIPTION
See https://github.com/ory/sdk/issues/381